### PR TITLE
Update phone regex patterns

### DIFF
--- a/csv/schema/full_import.csvs
+++ b/csv/schema/full_import.csvs
@@ -29,8 +29,8 @@ group: length(*, 255) @optional
 // Gender: can be "male", "female" or "other", optional.
 gender: is("male") or is("female") or is("other") @ignoreCase @optional
 // Phone, mobile and work: user's mobile and work phone number, both optional.
-phones_mobile: regex("^[0-9 +()-]+$") and length(*, 255) @optional
-phones_work: regex("^[0-9 +()-]+$") and length(*, 255) @optional
+phones_mobile: regex("^[0-9 +()x./-]+$") and length(*, 255) @optional
+phones_work: regex("^[0-9 +()x./-]+$") and length(*, 255) @optional
 // Birthday: user's date of birth, optional.
 birthday: xDate @optional
 // Work start date: when the employee started working for the company, optional.

--- a/csv/schema/user_import.csvs
+++ b/csv/schema/user_import.csvs
@@ -25,8 +25,8 @@ group: length(*, 255) @optional
 // Gender: can be "male", "female" or "other", optional.
 gender: is("male") or is("female") or is("other") @ignoreCase @optional
 // Phone, mobile and work: user's mobile and work phone number, both optional.
-phones_mobile: regex("^[0-9 +()-]+$") and length(*, 255) @optional
-phones_work: regex("^[0-9 +()-]+$") and length(*, 255) @optional
+phones_mobile: regex("^[0-9 +()x./-]*$") and length(*, 255) @optional
+phones_work: regex("^[0-9 +()x./-]*$") and length(*, 255) @optional
 // Birthday: user's date of birth, optional.
 birthday: xDate @optional
 // Work start date: when the employee started working for the company, optional.

--- a/json/schema/full_import.schema.json
+++ b/json/schema/full_import.schema.json
@@ -129,15 +129,9 @@
           },
           "phone_mobile": {
             "description": "User's mobile phone number, should be in international format, optional.",
-            "type": "string",
-            "maxLength": 255,
-            "anyOf": [
+            "allOf": [
               {
-                "pattern": "^[0-9 +()-]+$",
-                "minLength": 1
-              },
-              {
-                "maxLength": 0
+                "$ref": "#/definitions/phoneNumber"
               }
             ]
           },
@@ -145,13 +139,9 @@
             "description": "User's work phone number, should be in international format, optional.",
             "type": "string",
             "maxLength": 255,
-            "anyOf": [
+            "allOf": [
               {
-                "pattern": "^[0-9 +()-]+$",
-                "minLength": 1
-              },
-              {
-                "maxLength": 0
+                "$ref": "#/definitions/phoneNumber"
               }
             ]
           }
@@ -202,6 +192,11 @@
           }
         ]
       }
+    },
+    "phoneNumber": {
+      "type": "string",
+      "maxLength": 255,
+      "pattern": "^[0-9 +()x./-]*$"
     }
   }
 }

--- a/json/schema/user_import.schema.json
+++ b/json/schema/user_import.schema.json
@@ -117,29 +117,17 @@
           },
           "phone_mobile": {
             "description": "User's mobile phone number, should be in international format, optional.",
-            "type": "string",
-            "maxLength": 255,
-            "anyOf": [
+            "allOf": [
               {
-                "pattern": "^[0-9 +()-]+$",
-                "minLength": 1
-              },
-              {
-                "maxLength": 0
+                "$ref": "#/definitions/phoneNumber"
               }
             ]
           },
           "phone_work": {
             "description": "User's work phone number, should be in international format, optional.",
-            "type": "string",
-            "maxLength": 255,
-            "anyOf": [
+            "allOf": [
               {
-                "pattern": "^[0-9 +()-]+$",
-                "minLength": 1
-              },
-              {
-                "maxLength": 0
+                "$ref": "#/definitions/phoneNumber"
               }
             ]
           }
@@ -186,6 +174,11 @@
           }
         ]
       }
+    },
+    "phoneNumber": {
+      "type": "string",
+      "maxLength": 255,
+      "pattern": "^[0-9 +()x./-]*$"
     }
   }
 }

--- a/xml/schema/full_import.xsd
+++ b/xml/schema/full_import.xsd
@@ -82,7 +82,7 @@
     </xs:simpleType>
     <xs:simpleType name="phoneNumber">
         <xs:restriction base="optionalString">
-            <xs:pattern value="\s*|[0-9 +()-]+"/>
+            <xs:pattern value="\s*|[0-9 +()x./-]+"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="userElement">

--- a/xml/schema/user_import.xsd
+++ b/xml/schema/user_import.xsd
@@ -76,7 +76,7 @@
     </xs:simpleType>
     <xs:simpleType name="phoneNumber">
         <xs:restriction base="optionalString">
-            <xs:pattern value="\s*|[0-9 +()-]+"/>
+            <xs:pattern value="\s*|[0-9 +()x./-]+"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="userElement">


### PR DESCRIPTION
Allow "x", "." and "/" characters that are used in some national phone number formats or used to denote extensions.