### PR TITLE
Make user-only schema less strict

### DIFF
--- a/csv/schema/user_import.csvs
+++ b/csv/schema/user_import.csvs
@@ -2,9 +2,9 @@ version 1.1
 @totalColumns 15
 @ignoreColumnNameCase
 @separator ','
-// Employee ID: unique within company, e.g., policy number. Optional if email is present.
-employee_id: notEmpty or $email/notEmpty and length(*, 36)
-// Email: user's email address, optional.
+// Employee ID: unique within company, e.g., policy number. Required if this feature is enabled for the company.
+employee_id: length(*, 36) @optional
+// Email: user's email address, optional if the company uses employee_id.
 email: regex("^[\w!#$%&’*+/=?`{|}~^-]+(?:\.[\w!#$%&’*+/=?`{|}~^-]+)*@(?:[a-z0-9-]+\.)+[a-z]{2,63}$") @ignoreCase @optional
 // User's first and last name, optional.
 first_name: length(*, 255) @optional

--- a/json/schema/user_import.schema.json
+++ b/json/schema/user_import.schema.json
@@ -13,18 +13,24 @@
         "type": "object",
         "properties": {
           "employee_id": {
-            "description": "Unique within company, e.g., policy number. Optional if email is present.",
+            "description": "Unique within company, e.g., policy number. Required if this feature is enabled for the company.",
             "type": "string",
-            "minLength": 1,
             "maxLength": 36
           },
           "email": {
             "$ref": "#/definitions/email/rfc-5322"
           },
           "activation_date": {
-            "description": "Date when account should become active in ISO 8601 format, i.e., YYYY-MM-DD. Required. Should be a future date.",
+            "description": "Date when account should become active in ISO 8601 format, i.e., YYYY-MM-DD. Optional.",
             "type": "string",
-            "format": "date"
+            "anyOf": [
+              {
+                "format": "date"
+              },
+              {
+                "maxLength": 0
+              }
+            ]
           },
           "termination_date": {
             "description": "Date when account should be terminated in ISO 8601 format, i.e., YYYY-MM-DD. Optional.",
@@ -132,25 +138,6 @@
             ]
           }
         },
-        "anyOf": [
-          {
-            "description": "Email is required when employee_id is not present.",
-            "required": [
-              "email"
-            ],
-            "properties": {
-              "email": {
-                "minLength": 1
-              }
-            }
-          },
-          {
-            "description": "Email is optional when employee_id is present (default case).",
-            "required": [
-              "employee_id"
-            ]
-          }
-        ],
         "additionalProperties": false
       }
     }
@@ -162,7 +149,7 @@
   "definitions": {
     "email": {
       "rfc-5322": {
-        "description": "User's email address as defined in RFC 5322, optional if employee_id is present.",
+        "description": "User's email address as defined in RFC 5322, optional if the company uses employee_id.",
         "type": "string",
         "anyOf": [
           {


### PR DESCRIPTION
In case of user-only files the employee_id usage is controlled by the given existing company's feature availability, so if the employee_id is enabled then it is required and email is optional, if not then the email is required and employee_id is optional (can be left empty).

This additional business logic is not possible to be expressed in the schemas so in case of user-only imports both the employee_id and email are optional and can be empty. The import process ensures that the appropriate unique ID is present in all records, on top of validating against the schema.