### PR TITLE
Country code and locale must not be empty

### DIFF
--- a/json/examples/full_import.json
+++ b/json/examples/full_import.json
@@ -58,7 +58,6 @@
       "company_name": "Company Name",
       "activation_date": "2020-01-01",
       "group": "",
-      "country_code": "",
       "first_name": "",
       "last_name": "",
       "job_title": "",

--- a/json/schema/full_import.schema.json
+++ b/json/schema/full_import.schema.json
@@ -58,28 +58,14 @@
           "country_code": {
             "description": "User's country, 2 letter country code, uppercase, optional.",
             "type": "string",
-            "anyOf": [
-              {
-                "pattern": "^[A-Z]{2}$",
-                "minLength": 1
-              },
-              {
-                "maxLength": 0
-              }
-            ]
+            "pattern": "^[A-Z]{2}$",
+            "minLength": 1
           },
           "locale": {
             "description": "User's locale string in ISO/IEC 15897 format, e.g., en_GB, pt_BR, etc. Optional.",
             "type": "string",
-            "anyOf": [
-              {
-                "pattern": "^[a-z]{2}_[A-Z]{2}$",
-                "minLength": 1
-              },
-              {
-                "maxLength": 0
-              }
-            ]
+            "pattern": "^[a-z]{2}_[A-Z]{2}$",
+            "minLength": 1
           },
           "first_name": {
             "type": "string",

--- a/json/schema/user_import.schema.json
+++ b/json/schema/user_import.schema.json
@@ -52,28 +52,14 @@
           "country_code": {
             "description": "User's country, 2 letter country code, uppercase, optional.",
             "type": "string",
-            "anyOf": [
-              {
-                "pattern": "^[A-Z]{2}$",
-                "minLength": 1
-              },
-              {
-                "maxLength": 0
-              }
-            ]
+            "pattern": "^[A-Z]{2}$",
+            "minLength": 1
           },
           "locale": {
             "description": "User's locale string in ISO/IEC 15897 format, e.g., en_GB, pt_BR, etc. Optional.",
             "type": "string",
-            "anyOf": [
-              {
-                "pattern": "^[a-z]{2}_[A-Z]{2}$",
-                "minLength": 1
-              },
-              {
-                "maxLength": 0
-              }
-            ]
+            "pattern": "^[a-z]{2}_[A-Z]{2}$",
+            "minLength": 1
           },
           "first_name": {
             "type": "string",

--- a/xml/examples/full_import.xml
+++ b/xml/examples/full_import.xml
@@ -59,8 +59,6 @@
         <activation_date>2018-11-20</activation_date>
         <first_name>  </first_name>
         <last_name/>
-        <country_code>   </country_code>
-        <locale/>
         <gender/>
         <job_title/>
         <phone_mobile>   </phone_mobile>

--- a/xml/examples/user_import.xml
+++ b/xml/examples/user_import.xml
@@ -51,8 +51,6 @@
         <activation_date>2018-11-20</activation_date>
         <first_name>  </first_name>
         <last_name/>
-        <country_code>   </country_code>
-        <locale/>
         <gender/>
         <job_title/>
         <phone_mobile>   </phone_mobile>

--- a/xml/schema/full_import.xsd
+++ b/xml/schema/full_import.xsd
@@ -10,12 +10,12 @@
     </xs:annotation>
     <xs:simpleType name="countryCode">
         <xs:restriction base="xs:string">
-            <xs:pattern value="\s*|[A-Z]{2}"/>
+            <xs:pattern value="[A-Z]{2}"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="locale">
         <xs:restriction base="xs:string">
-            <xs:pattern value="\s*|[a-z]{2}_[A-Z]{2}"/>
+            <xs:pattern value="[a-z]{2}_[A-Z]{2}"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="emailRFC5322">

--- a/xml/schema/user_import.xsd
+++ b/xml/schema/user_import.xsd
@@ -10,12 +10,12 @@
     </xs:annotation>
     <xs:simpleType name="countryCode">
         <xs:restriction base="xs:string">
-            <xs:pattern value="\s*|[A-Z]{2}"/>
+            <xs:pattern value="[A-Z]{2}"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="locale">
         <xs:restriction base="xs:string">
-            <xs:pattern value="\s*|[a-z]{2}_[A-Z]{2}"/>
+            <xs:pattern value="[a-z]{2}_[A-Z]{2}"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="emailRFC5322">


### PR DESCRIPTION
We still allow these fields to be omitted in some or all user records, but when they are present then they must have a value.